### PR TITLE
add eBGP support (remote-as option)

### DIFF
--- a/cmd/parrot/main.go
+++ b/cmd/parrot/main.go
@@ -24,7 +24,8 @@ var opts parrot.Options
 var neighbors Neighbors
 
 func init() {
-	flag.IntVar(&opts.As, "as", 65000, "global AS")
+	flag.IntVar(&opts.As, "as", 65000, "local BGP ASN")
+	flag.IntVar(&opts.RemoteAs, "remote-as", 0, "remote BGP ASN. Default to local ASN (iBGP)")
 	flag.StringVar(&opts.NodeName, "nodename", "", "Name of the node this pod is running on")
 	flag.IPVar(&opts.HostIP, "hostip", net.ParseIP("127.0.0.1"), "IP")
 	flag.IntVar(&opts.MetricsPort, "metric-port", 30039, "Port for Prometheus metrics")
@@ -38,6 +39,10 @@ func main() {
 	goflag.CommandLine.Parse([]string{})
 	flag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 	flag.Parse()
+
+	if opts.RemoteAs == 0 {
+		opts.RemoteAs = opts.As
+	}
 
 	sigs := make(chan os.Signal, 1)
 	stop := make(chan struct{})

--- a/pkg/bgp/server.go
+++ b/pkg/bgp/server.go
@@ -19,6 +19,7 @@ type Server struct {
 	grpc *api.Server
 
 	as           uint32
+	remoteAs     uint32
 	routerId     string
 	localAddress string
 
@@ -26,11 +27,12 @@ type Server struct {
 	NodePodSubnetRoutes *NodePodSubnetRoutesStore
 }
 
-func NewServer(localAddress *net.IP, as int, port int) *Server {
+func NewServer(localAddress *net.IP, as int, remoteAs int, port int) *Server {
 	server := &Server{
 		localAddress: localAddress.String(),
 		routerId:     localAddress.String(),
 		as:           uint32(as),
+		remoteAs:     uint32(remoteAs),
 	}
 
 	server.ExternalIPRoutes = newExternalIPRoutesStore(server)
@@ -77,11 +79,11 @@ func (s *Server) startServer() {
 }
 
 func (s *Server) AddNeighbor(neighbor string) {
-	glog.Infof("Adding Neighbor: %s", neighbor)
+	glog.Infof("Adding Neighbor: %s remote ASN %d", neighbor, s.remoteAs)
 	n := &config.Neighbor{
 		Config: config.NeighborConfig{
 			NeighborAddress: neighbor,
-			PeerAs:          s.as,
+			PeerAs:          s.remoteAs,
 		},
 	}
 

--- a/pkg/parrot/parrot.go
+++ b/pkg/parrot/parrot.go
@@ -21,6 +21,7 @@ var (
 type Options struct {
 	GrpcPort      int
 	As            int
+	RemoteAs      int
 	NodeName      string
 	HostIP        net.IP
 	Neighbors     []*net.IP
@@ -44,7 +45,7 @@ type Parrot struct {
 func New(opts Options) *Parrot {
 	p := &Parrot{
 		Options: opts,
-		bgp:     bgp.NewServer(&opts.HostIP, opts.As, opts.GrpcPort),
+		bgp:     bgp.NewServer(&opts.HostIP, opts.As, opts.RemoteAs, opts.GrpcPort),
 		client:  NewClient(),
 	}
 


### PR DESCRIPTION
For global region we need to support eBGP by configuring different neighbour ASN than we have locally.

e.g. `./parrot --as=4268359685 --remote-as=65001`